### PR TITLE
Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 
 RUN go build -o az-dump main.go
 
-FROM alpine:3.21.3
+FROM mcr.microsoft.com/azure-cli:2.73.0
 LABEL org.opencontainers.image.source=https://github.com/nu12/az-dump
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Move binary to a bin folder in your PATH (may require elevated permissions):
 mv az-dump /usr/local/bin/
 ```
 
+## Dependencies
+
+The local terminal session must have `az` CLI installed and the account to be used must be logged in with `az login`. Access to subscription, resource groups and other resources are managed by the cloud provider.
+
 ## Usage
 
 General usage for all commands is `az-dump [command] [flags]`. Find out all available commands with `az-dump`:


### PR DESCRIPTION
Without `az` present `az-dump` is pratically unusable. 

Added a note for dependencies in README.